### PR TITLE
Remove app volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN sh $BITNAMI_PREFIX/install.sh\
 COPY rootfs/ /
 
 EXPOSE 9000
-VOLUME ["/app", "$BITNAMI_APP_VOL_PREFIX/logs", "$BITNAMI_APP_VOL_PREFIX/conf"]
+VOLUME ["$BITNAMI_APP_VOL_PREFIX/logs", "$BITNAMI_APP_VOL_PREFIX/conf"]
 WORKDIR /app
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ using the `bats` command.
 bats test.sh
 ```
 
+# Changelog
+
+## development (2015-10-05)
+
+- `/app` directory is no longer exported as a volume. This caused problems when building on top of the image, since changes in the volume are not persisted between Dockerfile `RUN` instructions. To keep the previous behavior (so that you can mount the volume in another container), create the container with the `-v /app` option.
+
 # Contributing
 
 We'd love for you to contribute to this Docker image. You can request new features by creating an

--- a/rootfs/etc/cont-init.d/01-bitnami-php-fpm
+++ b/rootfs/etc/cont-init.d/01-bitnami-php-fpm
@@ -2,11 +2,11 @@
 set -e
 source $BITNAMI_PREFIX/bitnami-utils.sh
 
+if [ ! "$(ls -A $BITNAMI_APP_VOL_PREFIX/conf)" ]; then
+  generate_conf_files $BITNAMI_APP_DIR/etc
+fi
+
 sudo chown -R $BITNAMI_APP_USER:$BITNAMI_APP_USER \
   $BITNAMI_APP_VOL_PREFIX/conf/ \
   $BITNAMI_APP_VOL_PREFIX/logs/ \
   /app || true
-
-if [ ! "$(ls -A $BITNAMI_APP_VOL_PREFIX/conf)" ]; then
-  generate_conf_files $BITNAMI_APP_DIR/etc
-fi


### PR DESCRIPTION
Specifying a volume at `/app` (in the Dockerfile) makes it difficult to 
use this image as a base image for derived images. Due to this, we have
removed the `VOLUME` instruction that mounts `/app` as a volume.

The `/app` path continues to function like it did before. As a result if 
you want to mount your php application into the container, mount your 
application source at `/app` using `-v 
/path/on/application/source:/app`.

One advantage of mounting/installing your application at `/app` is that
the image will automatically update the ownership of the
files/directories in `/app` so that it is accessible by the `php-fpm`
process.
