### PR TITLE
Made chown only change the GROUP owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_IMAGE_VERSION=7.0.6-r0 \
     BITNAMI_APP_NAME=php-fpm \
-    BITNAMI_APP_USER=daemon
+    BITNAMI_APP_USER=daemon \
+    BITNAMI_APP_GROUP=daemon \
 
 RUN bitnami-pkg unpack php-7.0.6-0 --checksum 8ca32e21642fbe2fd23cdf7459d6cb4b65bb1b89b0e230333c8da553135d79a6
 RUN mkdir -p /bitnami && ln -sf /bitnami/php /bitnami/php-fpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_IMAGE_VERSION=7.0.6-r0 \
     BITNAMI_APP_NAME=php-fpm \
-    BITNAMI_APP_USER=daemon \
-    BITNAMI_APP_GROUP=daemon
+    BITNAMI_APP_USER=daemon
 
 RUN bitnami-pkg unpack php-7.0.6-0 --checksum 8ca32e21642fbe2fd23cdf7459d6cb4b65bb1b89b0e230333c8da553135d79a6
 RUN mkdir -p /bitnami && ln -sf /bitnami/php /bitnami/php-fpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 ENV BITNAMI_IMAGE_VERSION=7.0.6-r0 \
     BITNAMI_APP_NAME=php-fpm \
     BITNAMI_APP_USER=daemon \
-    BITNAMI_APP_GROUP=daemon \
+    BITNAMI_APP_GROUP=daemon
 
 RUN bitnami-pkg unpack php-7.0.6-0 --checksum 8ca32e21642fbe2fd23cdf7459d6cb4b65bb1b89b0e230333c8da553135d79a6
 RUN mkdir -p /bitnami && ln -sf /bitnami/php /bitnami/php-fpm

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -8,6 +8,6 @@ if [[ "$1" == "harpoon" && "$2" == "start" ]]; then
   fi
 fi
 
-chown $BITNAMI_APP_USER: /bitnami/$BITNAMI_APP_NAME || true
+chown $BITNAMI_APP_USER:$BITNAMI_APP_GROUP /bitnami/$BITNAMI_APP_NAME || true
 
 exec /entrypoint.sh "$@"

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -8,6 +8,6 @@ if [[ "$1" == "harpoon" && "$2" == "start" ]]; then
   fi
 fi
 
-chown $BITNAMI_APP_USER:$BITNAMI_APP_GROUP /bitnami/$BITNAMI_APP_NAME || true
+chown -R :$BITNAMI_APP_GROUP /bitnami/$BITNAMI_APP_NAME || true
 
 exec /entrypoint.sh "$@"

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -8,6 +8,6 @@ if [[ "$1" == "harpoon" && "$2" == "start" ]]; then
   fi
 fi
 
-chown -R :$BITNAMI_APP_GROUP /bitnami/$BITNAMI_APP_NAME || true
+chown -R :$BITNAMI_APP_USER /bitnami/$BITNAMI_APP_NAME || true
 
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
chmod should only change the group. It should be up to the user to assign enough permissions to the group. Then, a user can have full control of the files from the "host".