### PR TITLE
replace the bundled common libraries with references to system packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM gcr.io/stacksmith-images/minideb:jessie-r2
+FROM gcr.io/stacksmith-images/minideb:jessie-r4
 MAINTAINER Bitnami <containers@bitnami.com>
 
-ENV BITNAMI_IMAGE_VERSION=7.0.12-r1 \
+ENV BITNAMI_IMAGE_VERSION=7.0.13-r0 \
     BITNAMI_APP_NAME=php-fpm \
     BITNAMI_APP_USER=daemon
 
-RUN bitnami-pkg unpack php-7.0.12-1 --checksum d6e73b25677e4beae79c6536b1f7e6d9f23c153d62b586f16e334782a6868eb2
+# System packages required
+RUN install_packages --no-install-recommends libc6 zlib1g libxslt1.1 libtidy-0.99-0 libreadline6 libncurses5 libtinfo5 libsybdb5 libmcrypt4 libldap-2.4-2 libstdc++6 libgmp10 libpng12-0 libjpeg62-turbo libbz2-1.0 libxml2 libssl1.0.0 libcurl3 libfreetype6 libicu52 libgcc1 libgcrypt20 libgssapi-krb5-2 libgnutls-deb0-28 libsasl2-2 liblzma5 libidn11 librtmp1 libssh2-1 libkrb5-3 libk5crypto3 libcomerr2 libgpg-error0 libkrb5support0 libkeyutils1 libp11-kit0 libtasn1-6 libnettle4 libhogweed2 libffi6
+
+RUN bitnami-pkg unpack php-7.0.13-1 --checksum 5f571dc337fc95be2e6dffe786c5c376f137fe9d09048239a8d7f0e3d425e464
 RUN mkdir -p /bitnami && ln -sf /bitnami/php /bitnami/php-fpm
 ENV PATH=/opt/bitnami/php/sbin:/opt/bitnami/php/bin:/opt/bitnami/common/bin:$PATH
 
+WORKDIR /app
+
 COPY rootfs/ /
-ENTRYPOINT ["/app-entrypoint.sh"]
-CMD ["nami", "start", "--foreground", "php"]
 
 VOLUME ["/bitnami/$BITNAMI_APP_NAME"]
 
-WORKDIR /app
-
 EXPOSE 9000
+
+ENTRYPOINT ["/app-entrypoint.sh"]
+
+CMD ["nami", "start", "--foreground", "php"]


### PR DESCRIPTION
Additional changes:
 - Updates the base image revision to `minideb-buildpack:jessie-r4`
 - Updates php version to `7.0.13`