### PR TITLE
Provide a mechanism to allow for additional php.ini files without rebuilding container.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir /opt/bitnami/php/logs && touch /opt/bitnami/php/logs/php-fpm.log
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="5.6.34-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 EXPOSE 9000
 

--- a/5.6/prod/Dockerfile
+++ b/5.6/prod/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=development /opt/bitnami/php /opt/bitnami/php
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="5.6.34-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 CMD ["php-fpm","-F","--pid","/opt/bitnami/php/tmp/php-fpm.pid","-y","/opt/bitnami/php/etc/php-fpm.conf"]

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir /opt/bitnami/php/logs && touch /opt/bitnami/php/logs/php-fpm.log
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.0.28-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 EXPOSE 9000
 

--- a/7.0/prod/Dockerfile
+++ b/7.0/prod/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=development /opt/bitnami/php /opt/bitnami/php
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.0.28-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 CMD ["php-fpm","-F","--pid","/opt/bitnami/php/tmp/php-fpm.pid","-y","/opt/bitnami/php/etc/php-fpm.conf"]

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir /opt/bitnami/php/logs && touch /opt/bitnami/php/logs/php-fpm.log
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.1.15-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 EXPOSE 9000
 

--- a/7.1/prod/Dockerfile
+++ b/7.1/prod/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=development /opt/bitnami/php /opt/bitnami/php
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.1.15-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 CMD ["php-fpm","-F","--pid","/opt/bitnami/php/tmp/php-fpm.pid","-y","/opt/bitnami/php/etc/php-fpm.conf"]

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir /opt/bitnami/php/logs && touch /opt/bitnami/php/logs/php-fpm.log
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.2.3-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 EXPOSE 9000
 

--- a/7.2/prod/Dockerfile
+++ b/7.2/prod/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=development /opt/bitnami/php /opt/bitnami/php
 
 ENV BITNAMI_APP_NAME="php-fpm" \
     BITNAMI_IMAGE_VERSION="7.2.3-r0" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:$PATH" \
+    PHP_INI_SCAN_DIR="/opt/bitnami/php/lib/php.d"
 
 CMD ["php-fpm","-F","--pid","/opt/bitnami/php/tmp/php-fpm.pid","-y","/opt/bitnami/php/etc/php-fpm.conf"]

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Docker's linking system uses container ids or names to reference containers. We 
 
 ```bash
 $ docker run -it --name phpfpm \
-  --network app-tier
+  --network app-tier \
+  -v ./php.d:/opt/bitnami/php/lib/php.d \
   -v /path/to/app:/app \
   bitnami/php-fpm
 ```
@@ -129,6 +130,7 @@ services:
     networks:
       - app-tier
     volumes:
+      - ./php.d:/opt/bitnami/php/lib/php.d
       - /path/to/app:/app
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -70,6 +70,8 @@ version: '2'
 services:
   phpfpm:
     image: 'bitnami/php-example:0.0.1'
+    volumes:
+      - ./php.d:/opt/bitnami/php/lib/php.d
   nginx:
     image: 'bitnami/nginx:latest'
     depends_on:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   phpfpm:
     image: 'bitnami/php-example:0.0.1'
+    volumes:
+      - ./php.d:/opt/bitnami/php/lib/php.d
   nginx:
     image: 'bitnami/nginx:latest'
     depends_on:

--- a/example/php.d/10-php.ini
+++ b/example/php.d/10-php.ini
@@ -1,0 +1,3 @@
+; An example INI file that is injected into the container allowing you to customize PHP's configuration without
+; requiring a rebuild of the container.
+error-reporting = E_ALL


### PR DESCRIPTION
**Description of the change**

Introduce the ability to add additional php.ini files, normally on a per-extension basis, into the Bitnami PHP-FPM docker container, without the need to rebuild the container.

**Benefits**

In addition to not needing to amend the default php.ini file, by having the extension related configuration files external to the container, the ability to temporarily enable or disable an extension is significantly easier.

**Possible drawbacks**

Potentially, an alternative approach would/could/should be used for injecting configuration into a 'black-box' container.

**Applicable issues**

https://github.com/bitnami/bitnami-docker-php-fpm/issues/96
https://github.com/bitnami/bitnami-docker-php-fpm/issues/99
https://github.com/bitnami/bitnami-docker-php-fpm/issues/100
https://github.com/bitnami/bitnami-docker-php-fpm/issues/101

**Additional information**

Using the environment variable to instruct PHP to scan an additional directory is an alternative to building php with the `--with-config-file-scan-dir` option configured.
